### PR TITLE
faster default sort

### DIFF
--- a/source/object-iteration.js
+++ b/source/object-iteration.js
@@ -23,7 +23,7 @@ create_comparator = function(order) {
 
 // default lexicographic sort comparator function
 lexicographic = function(a, b) {
-    return a > b;
+    return a > b ? 1 : -1;
 };
 
 indexOf = function(target, pairs, order) {


### PR DESCRIPTION
The default sort function currently returns a boolean:

```js
// default lexicographic sort comparator function
lexicographic = function(a, b) {
    return a > b;
};
```

That works, because `true` is coerced to `1` and `false` is coerced to `0`. But since `0` is equivalent to [shruggie], that means the function will in many cases need to be invoked more times to fully sort the array.

By changing it to this...

```js
// default lexicographic sort comparator function
lexicographic = function(a, b) {
    return a > b ? 1 : -1;
};
```

...we avoid the coercion and reduce the number of times the function needs to run.